### PR TITLE
Update justfile to watch only the day's directory

### DIFF
--- a/2023/rust/justfile
+++ b/2023/rust/justfile
@@ -1,6 +1,6 @@
 # Use `just work day-01 part1` to work on the specific binary for a specific day's problems
 work day part:
-    cargo watch -x "check -p {{day}}" -s "just test {{part}} -p {{day}}" -s "just lint {{day}}" -s "just bench {{day}} {{part}}" -s "just flamegraph {{day}} {{part}}"
+    cargo watch -w {{day}} -x "check -p {{day}}" -s "just test {{part}} -p {{day}}" -s "just lint {{day}}" -s "just bench {{day}} {{part}}" -s "just flamegraph {{day}} {{part}}"
 www-watch:
    RUST_LOG=info cargo +nightly leptos watch --project www
 www-build:


### PR DESCRIPTION
Changed `cargo watch` to just watch the day's directory (without this it immediately re-triggers the run on my system).