### PR TITLE
divide by two trick to get rid of match expression

### DIFF
--- a/2023/rust/day-04/src/part1.rs
+++ b/2023/rust/day-04/src/part1.rs
@@ -27,10 +27,7 @@ impl Card {
             .intersection(&self.my_numbers)
             .count() as u32;
 
-        match power.checked_sub(1) {
-            Some(num) => 2u32.pow(num),
-            None => 0,
-        }
+        2u32.pow(power + 1) >> 2
     }
 }
 

--- a/2023/rust/day-04/src/part1.rs
+++ b/2023/rust/day-04/src/part1.rs
@@ -27,7 +27,7 @@ impl Card {
             .intersection(&self.my_numbers)
             .count() as u32;
 
-        2u32.pow(power + 1) >> 2
+        2u32.pow(power) >> 1
     }
 }
 

--- a/2023/rust/day-04/src/part1_nom_supreme.rs
+++ b/2023/rust/day-04/src/part1_nom_supreme.rs
@@ -29,7 +29,7 @@ impl Card {
             .intersection(&self.my_numbers)
             .count() as u32;
 
-        2u32.pow(power + 1) >> 2
+        2u32.pow(power) >> 1
     }
 }
 

--- a/2023/rust/day-04/src/part1_nom_supreme.rs
+++ b/2023/rust/day-04/src/part1_nom_supreme.rs
@@ -29,10 +29,7 @@ impl Card {
             .intersection(&self.my_numbers)
             .count() as u32;
 
-        match power.checked_sub(1) {
-            Some(num) => 2u32.pow(num),
-            None => 0,
-        }
+        2u32.pow(power + 1) >> 2
     }
 }
 


### PR DESCRIPTION
Neat little math trick I wanted to share. I haven't done the performance analysis on this (yet) but I wonder if this is faster than the conditional. Marginal either way, I suspect, just thought it was neat

This works because the answer is 2^(n-1), but when n = 0 then we must return a score of 0. Dividing the result of the power by 2 is effectively the same as subtracting 1 from the exponent

n | target score | 2^n | 2^n >> 1
--|------|----|-
0 | 0 | 1 | 0
1 | 1 | 2 | 1
2 | 2 | 4 | 4
3 | 4 | 8 | 4