### PR TITLE
Fix daily template part2 todo message

### DIFF
--- a/2023/rust/daily-template/src/part2.rs
+++ b/2023/rust/daily-template/src/part2.rs
@@ -4,7 +4,7 @@ use crate::custom_error::AocError;
 pub fn process(
     _input: &str,
 ) -> miette::Result<String, AocError> {
-    todo!("day 01 - part 1");
+    todo!("day 01 - part 2");
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The daily template's todo message in the process function of part 2 still said `part 1`, which might confuse some people.