### PR TITLE
Reduce allocs in day 23 part 1 from 9710 to 272

### DIFF
--- a/2023/rust/day-23/src/part1.rs
+++ b/2023/rust/day-23/src/part1.rs
@@ -190,18 +190,18 @@ pub fn process(
 
     grid.iter()
         .flat_map(|plot| {
-            let possible_directions = match plot.r#type {
+            let possible_directions = match &plot.r#type {
                 PlotType::Directional(direction) => {
-                    vec![direction]
+                    std::slice::from_ref(direction)
                 }
-                PlotType::Empty => vec![
+                PlotType::Empty => &[
                     Direction::North,
                     Direction::South,
                     Direction::East,
                     Direction::West,
                 ],
             };
-            possible_directions.into_iter().filter_map(
+            possible_directions.iter().copied().filter_map(
                 |dir| {
                     let next_pos =
                         dir.step(&plot.span.extra);


### PR DESCRIPTION
This takes advantage of `std::slice::from_ref` and static promotion of constants to change `possible_directions` from a vec to a slice.

I ran Divan to get the allocation count difference.