### PR TITLE
see what removing then_some looks like

### DIFF
--- a/2023/rust/day-03/src/part2_nom.rs
+++ b/2023/rust/day-03/src/part2_nom.rs
@@ -102,12 +102,13 @@ pub fn process(
             let Value::Symbol(sym) = value else {
                 return None;
             };
-            let matching_numbers = POSITIONS
+            Some(sym)
+        })
+        .map(|sym| {
+            POSITIONS
                 .iter()
-                .map(|pos| *pos + sym.extra)
-                .filter_map(|surrounding_symbol_position| {
-                    number_map
-                        .get(&surrounding_symbol_position)
+                .filter_map(|pos| {
+                    number_map.get(&(*pos + sym.extra))
                 })
                 .unique()
                 .map(|(_, fragment)| {
@@ -115,11 +116,13 @@ pub fn process(
                         .parse::<i32>()
                         .expect("should be a valid number")
                 })
-                .collect::<Vec<i32>>();
-
-            (matching_numbers.len() == 2).then_some(
-                matching_numbers.iter().product::<i32>(),
-            )
+                .collect::<Vec<i32>>()
+        })
+        .filter(|matching_numbers| {
+            matching_numbers.len() == 2
+        })
+        .map(|matching_numbers| {
+            matching_numbers.iter().product::<i32>()
         })
         .sum::<i32>();
 

--- a/2023/rust/day-06/src/part1.rs
+++ b/2023/rust/day-06/src/part1.rs
@@ -31,11 +31,9 @@ pub fn process(
         .zip(distances)
         .map(|(time, record_distance)| {
             (0..time)
-                .filter_map(|speed| {
-                    let my_distance =
-                        (time - speed) * speed;
-                    (my_distance > record_distance)
-                        .then_some(my_distance)
+                .map(|speed| (time - speed) * speed)
+                .filter(|my_distance| {
+                    my_distance > &record_distance
                 })
                 .count()
         })

--- a/2023/rust/day-06/src/part2.rs
+++ b/2023/rust/day-06/src/part2.rs
@@ -32,10 +32,9 @@ pub fn process(
         parse_times(input).expect("a valid parse");
 
     let result = (0..time)
-        .filter_map(|speed| {
-            let my_distance = (time - speed) * speed;
-            (my_distance > record_distance)
-                .then_some(my_distance)
+        .map(|speed| (time - speed) * speed)
+        .filter(|my_distance| {
+            my_distance > &record_distance
         })
         .count();
 

--- a/2023/rust/day-07/src/part2.rs
+++ b/2023/rust/day-07/src/part2.rs
@@ -34,9 +34,8 @@ fn score_hand(
         } else {
             counts
                 .iter()
-                .filter_map(|(key, value)| {
-                    (key != &'J').then_some(value)
-                })
+                .filter(|(key, _)| (key != &&'J'))
+                .map(|(_, value)| value)
                 .sorted()
                 .with_position()
                 .map(|(position, value)| match position {

--- a/2023/rust/day-10/src/part1.rs
+++ b/2023/rust/day-10/src/part1.rs
@@ -111,12 +111,14 @@ fn parse_grid(
         input,
         output
             .into_iter()
-            .filter_map(|pipe_info| {
-                (pipe_info.pipe_type != PipeType::Ground)
-                    .then_some((
-                        pipe_info.span.extra,
-                        pipe_info.pipe_type,
-                    ))
+            .filter(|pipe_info| {
+                pipe_info.pipe_type != PipeType::Ground
+            })
+            .map(|pipe_info| {
+                (
+                    pipe_info.span.extra,
+                    pipe_info.pipe_type,
+                )
             })
             .collect(),
     ))

--- a/2023/rust/day-11/src/part2.rs
+++ b/2023/rust/day-11/src/part2.rs
@@ -12,9 +12,8 @@ pub fn process(
     let empty_rows = input
         .lines()
         .enumerate()
-        .filter_map(|(index, line)| {
-            line.chars().all(|c| c == '.').then_some(index)
-        })
+        .filter(|(_, line)| line.chars().all(|c| c == '.'))
+        .map(|(index, _)| index)
         .collect::<Vec<usize>>();
 
     let mut columns = input

--- a/2023/rust/day-12/src/part1.rs
+++ b/2023/rust/day-12/src/part1.rs
@@ -82,10 +82,9 @@ impl<'a> Puzzle<'a> {
             .chars()
             .group_by(|c| c == &'#')
             .into_iter()
-            .filter_map(|(is_hashes, group)| {
-                is_hashes.then_some(
-                    group.into_iter().count() as u32,
-                )
+            .filter(|(is_hashes, _)| *is_hashes)
+            .map(|(_, group)| {
+                group.into_iter().count() as u32
             })
             .collect::<Vec<u32>>();
         info!(?counts);

--- a/2023/rust/day-12/src/part2.rs
+++ b/2023/rust/day-12/src/part2.rs
@@ -87,10 +87,9 @@ impl Puzzle {
             .chars()
             .group_by(|c| c == &'#')
             .into_iter()
-            .filter_map(|(is_hashes, group)| {
-                is_hashes.then_some(
-                    group.into_iter().count() as u32,
-                )
+            .filter(|(is_hashes, _)| *is_hashes)
+            .map(|(_, group)| {
+                group.into_iter().count() as u32
             })
             .collect::<Vec<u32>>();
         info!(?counts);

--- a/2023/rust/day-20/src/part2.rs
+++ b/2023/rust/day-20/src/part2.rs
@@ -1,6 +1,4 @@
-use std::{
-    collections::{HashMap, VecDeque},
-};
+use std::collections::{HashMap, VecDeque};
 
 use nom::{
     branch::alt,
@@ -84,7 +82,12 @@ impl<'a> Machine<'a> {
 
                 let new_signal = if memory
                     .values()
-                    .all(|s| s == &Signal::High) { Signal::Low } else { Signal::High };
+                    .all(|s| s == &Signal::High)
+                {
+                    Signal::Low
+                } else {
+                    Signal::High
+                };
                 self.output
                     .iter()
                     .map(|id| {
@@ -178,21 +181,17 @@ pub fn process(
     let final_node = "rx";
     let penultimate_node = machines
         .iter()
-        .find_map(|(id, machine)| {
-            machine
-                .output
-                .contains(&final_node)
-                .then_some(*id)
+        .find(|(_, machine)| {
+            machine.output.contains(&final_node)
         })
+        .map(|(id, _)| id)
         .unwrap();
     let mut penultimate_nodes = machines
         .iter()
-        .filter_map(|(id, machine)| {
-            machine
-                .output
-                .contains(&penultimate_node)
-                .then_some(*id)
+        .filter(|(_, machine)| {
+            machine.output.contains(&penultimate_node)
         })
+        .map(|(id, _)| *id)
         .collect::<Vec<&str>>();
 
     let conjunctions = machines

--- a/2023/rust/day-21/src/part2.rs
+++ b/2023/rust/day-21/src/part2.rs
@@ -102,10 +102,9 @@ pub fn process(
                     IVec2::NEG_Y,
                 ]
                 .into_iter()
-                .filter_map(|offset| {
-                    let cell = offset + *pos;
+                .map(|offset| offset + *pos)
+                .filter(|cell| {
                     set.contains(&(cell.rem_euclid(bounds)))
-                        .then_some(cell)
                 })
                 .for_each(|pos| {
                     new_set.insert(pos);


### PR DESCRIPTION
A temporary pull request to see what addressing the clippy lint [filter_map_bool_then](https://rust-lang.github.io/rust-clippy/master/index.html#/filter_map_bool_then) looks like.

The [original issue](https://github.com/rust-lang/rust-clippy/issues/9098) that motivates the clippy lint seems like it is motivated not by `then_some` usage, but rather by a large nested computation that wasn't abstracted into a function. The lint itself ignores this and places the burden on *any* `then_some` usage, which I think is a miss for the original issue. However, as the original issue doesn't contain the original code that prompted the lint in the first place, its hard to say one way or the other.

In day 06 this replacement seems ok, but in other similar days like day 11 it results in multiple closures where some arguments are ignored. First the first argument, then the second. Day 07 in particular moves from being a single-line to being two closures that ignore different parts of the input.

Day 03 in particular feels like I'd be bending over backwards to satisfy the lint, with the result ending up being multiple filter, map, and filter_map calls.

In none of the cases is the issue that motivated the original lint used. There are no highly-complex functions that use "a dozen lines" (language used in the original issue), so I don't think I'm going to follow this style lint here. Luckily the lint doesn't even actually catch the use cases here, so its not even something that needs to be allow'd.