### PR TITLE
Use runtime arguments in Divan benchmarks

### DIFF
--- a/2023/rust/Cargo.lock
+++ b/2023/rust/Cargo.lock
@@ -2884,9 +2884,9 @@ checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
 name = "divan"
-version = "0.1.7"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f3c37609833a14a598385904bd43c79724964bc4b0a3339968da85bec4e1e4"
+checksum = "5398159ee27f2b123d89b856bad61725442f37df5fb98c30cd570c318d594aee"
 dependencies = [
  "cfg-if",
  "clap 4.4.10",
@@ -2898,9 +2898,9 @@ dependencies = [
 
 [[package]]
 name = "divan-macros"
-version = "0.1.7"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4669c6c0b93fa1848f1aaebd95d2697e3216fd781ac9eb71527e578d9df0f8e"
+checksum = "5092f66eb3563a01e85552731ae82c04c934ff4efd7ad1a0deae7b948f4b3ec4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/2023/rust/Cargo.toml
+++ b/2023/rust/Cargo.toml
@@ -14,7 +14,7 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["fmt", "env-filter"] }
 rstest = "0.18.2"
 rstest_reuse = "0.6.0"
-divan = "0.1.7"
+divan = "0.1.11"
 tracing-tracy = "0.10.4"
 tracy-client = "0.16.4"
 tracy-client-sys = "0.22.0"

--- a/2023/rust/day-11/benches/benchmarks.rs
+++ b/2023/rust/day-11/benches/benchmarks.rs
@@ -13,7 +13,7 @@ fn part1() {
     .unwrap();
 }
 
-#[divan::bench(consts = [
+#[divan::bench(args = [
     2,
     10,
     100,
@@ -21,10 +21,10 @@ fn part1() {
     100000,
     1000000
 ])]
-fn part2<const N: i64>() {
+fn part2(n: i64) {
     part2::process(
         divan::black_box(include_str!("../input2.txt")),
-        divan::black_box(N),
+        n,
     )
     .unwrap();
 }

--- a/2023/rust/day-21/benches/benchmarks.rs
+++ b/2023/rust/day-21/benches/benchmarks.rs
@@ -5,26 +5,26 @@ fn main() {
     divan::main();
 }
 
-#[divan::bench(consts = [
+#[divan::bench(args = [
         6,
         64
     ])]
-fn part1<const N: usize>() {
+fn part1(n: usize) {
     part1::process(
         divan::black_box(include_str!("../input1.txt")),
-        divan::black_box(N),
+        n,
     )
     .unwrap();
 }
 
-#[divan::bench(consts = [
+#[divan::bench(args = [
     6,
     64
 ])]
-fn part2<const N: usize>() {
+fn part2(n: usize) {
     part2::process(
         divan::black_box(include_str!("../input2.txt",)),
-        divan::black_box(N),
+        n,
     )
     .unwrap();
 }


### PR DESCRIPTION
The new [`args`](https://docs.rs/divan/latest/divan/attr.bench.html#args) option greatly reduces compile times and is not limited to arrays/slices.