### PR TITLE
Add -S flag to provide multiple args to /usr/bin/env

### DIFF
--- a/2024/rust/scripts/get-aoc-input.rs
+++ b/2024/rust/scripts/get-aoc-input.rs
@@ -1,4 +1,4 @@
-#!/usr/bin/env cargo +nightly -Zscript
+#!/usr/bin/env -S cargo +nightly -Zscript
 ---cargo
 [package]
 edition = "2021"


### PR DESCRIPTION
I promised myself not to propose Pull request on day one this year, but here we are :-)
After execution of `just get-input day-01` I received:
```bash
./scripts/get-aoc-input.rs --day day-01 --current-working-directory /mnt/projects/Exercises/advent-of-code/2024/rust
/usr/bin/env: ‘cargo +nightly -Zscript’: No such file or directory
/usr/bin/env: use -[v]S to pass options in shebang lines
error: Recipe `get-input` failed on line 32 with exit code 127
```
To fix this I added `-S` flag (based on docs of cargo unstable features) in get-aoc-input.rs and it started to work.
```rust
#!/usr/bin/env -S cargo +nightly -Zscript
```
docs: https://doc.rust-lang.org/cargo/reference/unstable.html?highlight=-Z%20min#script 
```bash
 env --help
  -S, --split-string=S  process and split S into separate arguments;
                        used to pass multiple arguments on shebang lines
```
I do not have Windows or MacOS to test this. This issue happened on Pop!_OS, fish shell.