### PR TITLE
Update template to show correct days in todo message

### DIFF
--- a/2025/rust/daily-template/src/part1.rs
+++ b/2025/rust/daily-template/src/part1.rs
@@ -1,6 +1,6 @@
 #[tracing::instrument]
 pub fn process(_input: &str) -> miette::Result<String> {
-    todo!("day 01 - part 1");
+    todo!("{{project-name}} - part 1");
 }
 
 #[cfg(test)]

--- a/2025/rust/daily-template/src/part2.rs
+++ b/2025/rust/daily-template/src/part2.rs
@@ -1,6 +1,6 @@
 #[tracing::instrument]
 pub fn process(_input: &str) -> miette::Result<String> {
-    todo!("day 01 - part 2");
+    todo!("{{project-name}} - part 2");
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Template always said "day 01" in the message for the `todo!()` macro. This PR just updates it so that cargo-generate will update the message as well. 